### PR TITLE
Added ability to write manifest keys based on CSV columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A tool that allows Munki administrators to quickly create manifests based on a C
     ABCDEF10001
     ABCDEF10002
     ABCDEF10003
+    ...
     ```
 
     The header row can contain additional comma-seperated fields, which will be used to create additional keys in the resulting manifests. For example:
@@ -24,6 +25,7 @@ A tool that allows Munki administrators to quickly create manifests based on a C
     ABCDEF10001,"Loaner MacBook Pro",itservices
     ABCDEF10002,"Nick's iMac",nick
     ABCDEF10003,"Elliot's Mac Mini",elliot
+    ...
     ```
 
 1. Run `manifestcreator`:
@@ -35,5 +37,3 @@ A tool that allows Munki administrators to quickly create manifests based on a C
     :warning: `manifestcreator` will overwrite existing manifests with the same name as the newly created manifests.
 
 1. Check your manifests folder to verify that the new manifests have been created successfully.
-
-For additional help, run `./manifestcreator.py --help`.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,39 @@
 # manifestcreator
 
-Quickly create Munki manifests based on a CSV template.
+A tool that allows Munki administrators to quickly create manifests based on a CSV containing serial numbers.
 
-1. Create a CSV file that contains the serial numbers for which you want to create manifests, one per line.
-2. Create a manifest called Template in your Munki repo. The configuration of this manifest will be inherited by the newly created serial number manifests.
-3. Run manifestcreator using the following syntax:
+1. Create a template manifest.
+
+    This manifest should contain all the keys that will be _shared_ by the new serial number manifests you create. For example, you may want to include appropriate values for the `catalogs`, `managed_installs`, `managed_updates`, and `optional_installs` keys.
+
+1. Create a CSV file with serial numbers.
+
+    The CSV file should contain a header row. The first (and possibly only) field in the header row should be `serial`. For example:
+
+    ```
+    serial
+    ABCDEF10001
+    ABCDEF10002
+    ABCDEF10003
+    ```
+
+    The header row can contain additional comma-seperated fields, which will be used to create additional keys in the resulting manifests. For example:
+
+    ```
+    serial,display_name,user
+    ABCDEF10001,"Loaner MacBook Pro",itservices
+    ABCDEF10002,"Nick's iMac",nick
+    ABCDEF10003,"Elliot's Mac Mini",elliot
+    ```
+
+1. Run `manifestcreator`:
+
     ```
     ./manifestcreator.py --repo /path/to/munki_repo /path/to/serials.csv
     ```
-4. Check your manifests folder to verify that the new manifests have been created successfully.
+
+    :warning: `manifestcreator` will overwrite existing manifests with the same name as the newly created manifests.
+
+1. Check your manifests folder to verify that the new manifests have been created successfully.
 
 For additional help, run `./manifestcreator.py --help`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# manifestcreator
+
+Quickly create Munki manifests based on a CSV template.
+
+1. Create a CSV file that contains the serial numbers for which you want to create manifests, one per line.
+2. Create a manifest called Template in your Munki repo. The configuration of this manifest will be inherited by the newly created serial number manifests.
+3. Run manifestcreator using the following syntax:
+    ```
+    ./manifestcreator.py --repo /path/to/munki_repo /path/to/serials.csv
+    ```
+4. Check your manifests folder to verify that the new manifests have been created successfully.
+
+For additional help, run `./manifestcreator.py --help`.

--- a/manifestcreator.py
+++ b/manifestcreator.py
@@ -70,7 +70,7 @@ else:
 with open(arguments.file, "rb") as f:
     reader = csv.reader(f)
     for row in reader:
-        shutil.copyfile(
-            template, repo + "/manifests/" + row[0])
+        new_manifest = repo + "/manifests/" + row[0]
+        shutil.copyfile(template, new_manifest)
         if arguments.verbose is True:
-            print repo + "/manifests/" + row[0]
+            print new_manifest

--- a/manifestcreator.py
+++ b/manifestcreator.py
@@ -15,12 +15,11 @@
 # limitations under the License.
 
 """
-manifestcreator
-
-Quickly create Munki manifests based on a CSV template.
+A tool that allows Munki administrators to quickly create manifests based on a
+CSV containing serial numbers.
 
 positional arguments:
-  file                 Path to the CSV template file.
+  file                 Path to the CSV file containing serial numbers.
 
 optional arguments:
   -h, --help           show this help message and exit

--- a/manifestcreator.py
+++ b/manifestcreator.py
@@ -37,10 +37,11 @@ import argparse
 import plistlib
 
 p = argparse.ArgumentParser(
-    description="Quickly create Munki manifests based on a CSV template.")
+    description=("A tool that allows Munki administrators to quickly create "
+                 "manifests based on a CSV containing serial numbers."))
 p.add_argument(
     "file",
-    help="Path to the CSV template file.")
+    help="Path to the CSV file containing serial numbers.")
 p.add_argument(
     "-v", "--verbose",
     action="store_true",
@@ -74,9 +75,12 @@ except:
     raise
 
 with open(arguments.file, "rb") as f:
-    reader = csv.reader(f)
+    reader = csv.DictReader(f)
     for row in reader:
-        new_manifest = repo + "/manifests/" + row[0]
+        new_manifest = repo + "/manifests/" + row["serial"]
+        for key in row:
+            if key != "serial":
+                manifest_dict[key] = row[key]
         plistlib.writePlist(manifest_dict, new_manifest)
         if arguments.verbose is True:
             print new_manifest

--- a/manifestcreator.py
+++ b/manifestcreator.py
@@ -33,8 +33,8 @@ optional arguments:
 """
 
 import csv
-import shutil
 import argparse
+import plistlib
 
 p = argparse.ArgumentParser(
     description="Quickly create Munki manifests based on a CSV template.")
@@ -67,10 +67,16 @@ if arguments.template:
 else:
     template = repo + "/manifests/Template"
 
+try:
+    manifest_dict = plistlib.readPlist(template)
+except:
+    print "Manifest template might not be a valid plist file."
+    raise
+
 with open(arguments.file, "rb") as f:
     reader = csv.reader(f)
     for row in reader:
         new_manifest = repo + "/manifests/" + row[0]
-        shutil.copyfile(template, new_manifest)
+        plistlib.writePlist(manifest_dict, new_manifest)
         if arguments.verbose is True:
             print new_manifest

--- a/manifestcreator.py
+++ b/manifestcreator.py
@@ -20,11 +20,16 @@ manifestcreator
 Quickly create Munki manifests based on a CSV template.
 
 positional arguments:
-  file           Path to the CSV template file.
+  file                 Path to the CSV template file.
 
 optional arguments:
-  -h, --help     show this help message and exit
-  -v, --verbose  Outputs the path to each manifest as it is created.
+  -h, --help           show this help message and exit
+  -v, --verbose        Outputs the path to each manifest as it is created.
+  --repo REPO          The path to the Munki repository you want to add
+                       manifests to. Defaults to /Volumes/munki.
+  --template TEMPLATE  The path to the file you want to use as your manifest
+                       template. Defaults to
+                       /Volumes/munki/manifests/Template.
 """
 
 import csv
@@ -38,14 +43,34 @@ p.add_argument(
     help="Path to the CSV template file.")
 p.add_argument(
     "-v", "--verbose",
-	action="store_true",
+    action="store_true",
     help="Outputs the path to each manifest as it is created.")
+p.add_argument(
+    "--repo",
+    action="store",
+    help=("The path to the Munki repository you want to add manifests to. "
+          "Defaults to /Volumes/munki."))
+p.add_argument(
+    "--template",
+    action="store",
+    help=("The path to the file you want to use as your manifest template. "
+          "Defaults to /Volumes/munki/manifests/Template."))
 arguments = p.parse_args()
 
-with open(arguments.file, 'rb') as f:
+if arguments.repo:
+    repo = arguments.repo
+else:
+    repo = "/Volumes/munki"
+
+if arguments.template:
+    template = arguments.template
+else:
+    template = repo + "/manifests/Template"
+
+with open(arguments.file, "rb") as f:
     reader = csv.reader(f)
     for row in reader:
         shutil.copyfile(
-            '/Volumes/munki/manifests/Template', '/Volumes/munki/manifests/' + row[0])
+            template, repo + "/manifests/" + row[0])
         if arguments.verbose is True:
-            print '/Volumes/munki/manifests/' + row[0]
+            print repo + "/manifests/" + row[0]


### PR DESCRIPTION
The only non-backwards-compatible change is that `manifestcreator` now _requires_ a header row with `serial` as the first (and perhaps only) field. I've updated the read me to make this pretty clear.

Closes #2.
