### PR TITLE
Add "--nooverwrite" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ A tool that allows Munki administrators to quickly create manifests based on a C
     ./manifestcreator.py --repo /path/to/munki_repo /path/to/serials.csv
     ```
 
-    :warning: `manifestcreator` will overwrite existing manifests with the same name as the newly created manifests.
+    :warning: `manifestcreator` will overwrite existing manifests with the same name as the newly created manifests if you do not pass the "--nooverwrite" option.
 
 1. Check your manifests folder to verify that the new manifests have been created successfully.

--- a/manifestcreator.py
+++ b/manifestcreator.py
@@ -34,6 +34,7 @@ optional arguments:
 import csv
 import argparse
 import plistlib
+import os
 
 p = argparse.ArgumentParser(
     description=("A tool that allows Munki administrators to quickly create "
@@ -55,6 +56,11 @@ p.add_argument(
     action="store",
     help=("The path to the file you want to use as your manifest template. "
           "Defaults to /Volumes/munki/manifests/Template."))
+p.add_argument(
+    "--nooverwrite",
+    action="store_true",
+    help=("Do not overwrite existing files. Does not check to ensure the "
+          "existing files match the template."))
 arguments = p.parse_args()
 
 if arguments.repo:
@@ -80,6 +86,16 @@ with open(arguments.file, "rb") as f:
         for key in row:
             if key != "serial":
                 manifest_dict[key] = row[key]
-        plistlib.writePlist(manifest_dict, new_manifest)
+        if arguments.nooverwrite is True:
+            if os.path.exists(new_manifest):
+                if arguments.verbose is True:
+                    print "Skipping %s, file exists" % new_manifest
+                continue
+            else:
+                plistlib.writePlist(manifest_dict, new_manifest)
+        else:
+            # If false just write write the plists anyway
+            plistlib.writePlist(manifest_dict, new_manifest)
+
         if arguments.verbose is True:
             print new_manifest


### PR DESCRIPTION
Adds a quick and dirty option to not overwrite existing manifests on run. This can be useful if you're pulling serial number lists from an inventory tool like I am. It does not do any fancy checking to update according to the template, just ignores them if they exist and the flag is set.